### PR TITLE
basic path function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,4 @@ export {default as serialize}   from "./serialize.js";
 export {default as walk}        from "./walk.js";
 export {default as variables}   from "./variables.js";
 export * as parents             from "./parents.js";
+export {default as path}        from "./path.js";

--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,36 @@
+import { properties } from "./children.js";
+
+/**
+ * Find a path from an ancestor node to a descendant node.
+ * @param {object} ancestor the ancestor node to start the search from
+ * @param {object} descendant the descendant node to search for
+ * @returns {(string | number)[] | null} an array of keys to traverse to get from the ancestor to the descendant, or null if no path exists
+ */
+export default function path (ancestor, descendant) {
+	// Found descendant
+	if (ancestor === descendant) {
+		return [];
+	}
+
+	// Case where ancestor is an array for an array expression or compound etc
+	if (Array.isArray(ancestor)) {
+		for (let i = 0; i < ancestor.length; i++) {
+			const childPath = path(ancestor[i], descendant);
+			if (childPath) {
+				return [i].concat(childPath);
+			}
+		}
+		return null;
+	}
+
+	const childProperties = properties[ancestor.type] ?? [];
+
+	for (const property of childProperties) {
+		const childPath = path(ancestor[property], descendant);
+		if (childPath) {
+			return [property].concat(childPath);
+		}
+	}
+
+	return null;
+}

--- a/test/path.js
+++ b/test/path.js
@@ -1,0 +1,44 @@
+import jsep from "../node_modules/jsep/dist/jsep.min.js";
+import path from "../src/path.js";
+
+const expr = "1 + foo(bar, 1 + baz * 2)";
+const ast = jsep(expr);
+
+export default {
+	name: "path()",
+	run (ancestor, descendant) {
+		return path(ancestor, descendant);
+	},
+	tests: [
+		{
+			name: "Same node",
+			args: [ast, ast],
+			expect: []
+		},
+		{
+			name: "Path length 1",
+			args: [ast, ast.right],
+			expect: ["right"]
+		},
+		{
+			name: "Root to leaf",
+			args: [ast, ast.right.arguments[1].right.left],
+			expect: ["right", "arguments", 1, "right", "left"]
+		},
+		{
+			name: "Non-root to non-leaf",
+			args: [ast.right, ast.right.arguments[1]],
+			expect: ["arguments", 1]
+		},
+		{
+			name: "Non-root to leaf",
+			args: [ast.right, ast.right.arguments[0]],
+			expect: ["arguments", 0]
+		},
+		{
+			name: "Non-existent path",
+			args: [ast, jsep("dne")],
+			expect: null
+		}
+	]
+};


### PR DESCRIPTION
We need a basic path function to implement #34's augmentation in the first place, to determine the property/index that lead from a parent to a child. Eventually this is the type of function that should be moved into Treecle if we end up making that, but this is a quick PR so that we're not blocked on spinning up Treecle